### PR TITLE
Comments permissions

### DIFF
--- a/app/graphql/mutations/add_comment_mutation.rb
+++ b/app/graphql/mutations/add_comment_mutation.rb
@@ -7,10 +7,11 @@ module Mutations
     field :comment, Types::CommentType, null: true
 
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def resolve(attributes:)
       params = attributes.to_h
-      board = find_card(params).board
-      authorize! board, to: :create_comments?, context: { user: context[:current_user] }
+      card = Card.find(params[:card_id])
+      authorize! card.board, to: :create_comments?, context: { user: context[:current_user] }
 
       result = Boards::Cards::Comments::Create.new(current_user).call(comment_params(params))
 
@@ -25,10 +26,7 @@ module Mutations
       end
     end
     # rubocop:enable Metrics/MethodLength
-
-    def find_card(params)
-      Card.find_by!(id: params[:card_id].to_i)
-    end
+    # rubocop:enable Metrics/AbcSize
 
     def comment_params(params)
       params.merge(author: context[:current_user])

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,8 @@
 class Comment < ApplicationRecord
   belongs_to :card
   belongs_to :author, class_name: 'User'
+
+  has_many :comment_permissions_users, dependent: :destroy
   validates_presence_of :content
 
   def author?(user)

--- a/app/models/comment_permissions_user.rb
+++ b/app/models/comment_permissions_user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CommentPermissionsUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :permission
+  belongs_to :comment
+
+  validates_uniqueness_of :permission_id, scope: %i[user_id comment_id]
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -4,19 +4,24 @@ class Permission < ApplicationRecord
   CREATOR_IDENTIFIERS = %w[view_private_board edit_board update_board get_suggestions
                            destroy_board continue_board create_cards invite_members
                            toggle_ready_status destroy_membership destroy_any_card
-                           like_card].freeze
-  MEMBER_IDENTIFIERS = %w[view_private_board create_cards toggle_ready_status like_card].freeze
-  AUTHOR_IDENTIFIERS = %w[update_card destroy_card].freeze
+                           like_card create_comments].freeze
+  MEMBER_IDENTIFIERS = %w[view_private_board create_cards toggle_ready_status like_card
+                          create_comments].freeze
+  CARD_IDENTIFIERS = %w[update_card destroy_card].freeze
+  COMMENT_IDENTIFIERS = %w[update_comment destroy_comment].freeze
 
   has_many :board_permissions_users, dependent: :destroy
   has_many :board_users, through: :board_permissions_users, source: :user
   has_many :card_permissions_users, dependent: :destroy
   has_many :card_users, through: :card_permissions_users, source: :user
+  has_many :comment_permissions_users, dependent: :destroy
+  has_many :comment_users, through: :comment_permissions_users, source: :user
 
   validates_presence_of :description, :identifier
   validates_uniqueness_of :identifier
 
   scope :creator_permissions, -> { where(identifier: CREATOR_IDENTIFIERS) }
   scope :member_permissions, -> { where(identifier: MEMBER_IDENTIFIERS) }
-  scope :author_permissions, -> { where(identifier: AUTHOR_IDENTIFIERS) }
+  scope :card_permissions, -> { where(identifier: CARD_IDENTIFIERS) }
+  scope :comment_permissions, -> { where(identifier: COMMENT_IDENTIFIERS) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   has_many :board_permissions, through: :board_permissions_users, source: :permission
   has_many :card_permissions_users, dependent: :destroy
   has_many :card_permissions, through: :card_permissions_users, source: :permission
+  has_many :comment_permissions_users, dependent: :destroy
+  has_many :comment_permissions, through: :comment_permissions_users, source: :permission
   has_many :action_items, foreign_key: 'assignee_id', class_name: 'ActionItem'
 
   has_and_belongs_to_many :teams

--- a/app/operations/boards/cards/build_permissions.rb
+++ b/app/operations/boards/cards/build_permissions.rb
@@ -3,7 +3,7 @@
 module Boards
   module Cards
     class BuildPermissions
-      IDENTIFIERS_SCOPES = %w[author].freeze
+      IDENTIFIERS_SCOPES = %w[card].freeze
 
       include Dry::Monads[:result]
       attr_reader :card, :user

--- a/app/operations/boards/cards/comments/build_permissions.rb
+++ b/app/operations/boards/cards/comments/build_permissions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Boards
+  module Cards
+    module Comments
+      class BuildPermissions
+        IDENTIFIERS_SCOPES = %w[comment].freeze
+
+        include Dry::Monads[:result]
+        attr_reader :comment, :user
+
+        def initialize(comment, user)
+          @comment = comment
+          @user = user
+        end
+
+        def call(identifiers_scope:)
+          unless IDENTIFIERS_SCOPES.include?(identifiers_scope.to_s)
+            return Failure('Unknown permissions identifiers scope provided')
+          end
+
+          permissions_data = Permission.public_send(
+            "#{identifiers_scope}_permissions"
+          ).map do |permission|
+            { permission_id: permission.id, user_id: user.id }
+          end
+
+          comment.comment_permissions_users.build(permissions_data)
+          Success()
+        end
+      end
+    end
+  end
+end

--- a/app/operations/boards/cards/comments/create.rb
+++ b/app/operations/boards/cards/comments/create.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Boards
+  module Cards
+    module Comments
+      class Create
+        include Dry::Monads[:result]
+        attr_reader :user
+
+        def initialize(user)
+          @user = user
+        end
+
+        def call(comment_params)
+          comment = Comment.new(comment_params)
+
+          comment.transaction do
+            BuildPermissions.new(comment, user).call(identifiers_scope: 'comment')
+            comment.save!
+          end
+
+          Success(comment)
+        rescue StandardError => e
+          Failure(e)
+        end
+      end
+    end
+  end
+end

--- a/app/operations/boards/cards/create.rb
+++ b/app/operations/boards/cards/create.rb
@@ -14,7 +14,7 @@ module Boards
         card = Card.new(card_params)
 
         card.transaction do
-          BuildPermissions.new(card, user).call(identifiers_scope: 'author')
+          BuildPermissions.new(card, user).call(identifiers_scope: 'card')
           card.save!
         end
 

--- a/app/policies/board_policy.rb
+++ b/app/policies/board_policy.rb
@@ -45,6 +45,10 @@ class BoardPolicy < ApplicationPolicy
     user.allowed?('create_cards', record)
   end
 
+  def create_comments?
+    user.allowed?('create_comments', record)
+  end
+
   def suggestions?
     user.allowed?('get_suggestions', record)
   end

--- a/app/policies/card_policy.rb
+++ b/app/policies/card_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class CardPolicy < ApplicationPolicy
-  def create?
-    user.allowed?('create_cards', record.board)
-  end
-
   def update?
     user.allowed?('update_card', record)
   end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class CommentPolicy < ApplicationPolicy
-  def create?
-    check?(:create_comments?, find_board)
-  end
-
   def update?
     user.allowed?('update_comment', record)
   end
@@ -19,9 +15,5 @@ class CommentPolicy < ApplicationPolicy
 
   def user_not_author?
     !record.author?(user)
-  end
-
-  def find_board
-    Comment.includes(:card).find(record.id).card.board
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -2,26 +2,22 @@
 
 class CommentPolicy < ApplicationPolicy
   def create?
-    check?(:user_is_member?)
+    user.allowed?('create_comments', record.card.board)
   end
 
   def update?
-    check?(:user_is_author?)
+    user.allowed?('update_comment', record)
   end
 
   def destroy?
-    check?(:user_is_author?)
+    user.allowed?('destroy_comment', record)
   end
 
   def like?
-    !check?(:user_is_author?)
+    check?(:user_not_author?)
   end
 
-  def user_is_member?
-    record.card.board.memberships.exists?(user_id: user.id)
-  end
-
-  def user_is_author?
-    record.author?(user)
+  def user_not_author?
+    !record.author?(user)
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -2,7 +2,7 @@
 
 class CommentPolicy < ApplicationPolicy
   def create?
-    user.allowed?('create_comments', record.card.board)
+    check?(:create_comments?, find_board)
   end
 
   def update?
@@ -19,5 +19,9 @@ class CommentPolicy < ApplicationPolicy
 
   def user_not_author?
     !record.author?(user)
+  end
+
+  def find_board
+    Comment.includes(:card).find(record.id).card.board
   end
 end

--- a/db/migrate/20210301192210_create_comment_permissions_users.rb
+++ b/db/migrate/20210301192210_create_comment_permissions_users.rb
@@ -1,0 +1,15 @@
+class CreateCommentPermissionsUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comment_permissions_users do |t|
+      t.belongs_to :user
+      t.belongs_to :permission
+      t.belongs_to :comment
+
+      t.index %i[permission_id user_id comment_id],
+              unique: true,
+              name: 'index_comment_permissions_users_on_user_card_permission'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210301192210_create_comment_permissions_users.rb
+++ b/db/migrate/20210301192210_create_comment_permissions_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCommentPermissionsUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :comment_permissions_users do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_15_220017) do
+ActiveRecord::Schema.define(version: 2021_03_01_192210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,18 @@ ActiveRecord::Schema.define(version: 2021_02_15_220017) do
     t.integer "likes", default: 0
     t.index ["author_id"], name: "index_cards_on_author_id"
     t.index ["board_id"], name: "index_cards_on_board_id"
+  end
+
+  create_table "comment_permissions_users", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "permission_id"
+    t.bigint "comment_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["comment_id"], name: "index_comment_permissions_users_on_comment_id"
+    t.index ["permission_id", "user_id", "comment_id"], name: "index_comment_permissions_users_on_user_card_permission", unique: true
+    t.index ["permission_id"], name: "index_comment_permissions_users_on_permission_id"
+    t.index ["user_id"], name: "index_comment_permissions_users_on_user_id"
   end
 
   create_table "comments", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,12 +58,16 @@ permissions_data = {
   destroy_any_card: 'User can delete any card on a board',
   destroy_card: 'User can delete a card on a board',
   update_card: 'User can update a card on a board',
-  like_card: 'User can like a card on a board'
+  like_card: 'User can like a card on a board',
+  create_comments: 'User can create comments on board',
+  update_comment: 'User can update a card comment',
+  destroy_comment: 'User can delete a card comment',
+  like_comment: 'User can like a card comment'
 }
 
 errors = []
 
-(Permission::CREATOR_IDENTIFIERS | Permission::MEMBER_IDENTIFIERS | Permission::AUTHOR_IDENTIFIERS).each do |identifier|
+(Permission::CREATOR_IDENTIFIERS | Permission::MEMBER_IDENTIFIERS | Permission::CARD_IDENTIFIERS | Permission::COMMENT_IDENTIFIERS).each do |identifier|
   next if Permission.exists?(identifier: identifier)
 
   begin

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,6 +47,7 @@ Membership.create([
 permissions_data = {
   view_private_board: 'User can view private board',
   create_cards: 'User can create cards on board',
+  create_comments: 'User can create comments on board',
   edit_board: 'User can edit board',
   update_board: 'User can update board',
   destroy_board: 'User can destroy board',
@@ -59,7 +60,6 @@ permissions_data = {
   destroy_card: 'User can delete a card on a board',
   update_card: 'User can update a card on a board',
   like_card: 'User can like a card on a board',
-  create_comments: 'User can create comments on board',
   update_comment: 'User can update a card comment',
   destroy_comment: 'User can delete a card comment',
   like_comment: 'User can like a card comment'
@@ -116,3 +116,4 @@ ActionItem.create(body: 'actions should be taken', board_id: board1.id, author_i
 
 Rake::Task['permissions:create_missing_for_boards'].invoke
 Rake::Task['permissions:create_missing_for_cards'].invoke
+Rake::Task['permissions:create_missing_for_comments'].invoke

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -48,7 +48,7 @@ namespace :permissions do
     counter = 0
 
     Card.find_each do |card|
-      Permission.author_permissions.each do |permission|
+      Permission.card_permissions.each do |permission|
         permissions_users_data = { card: card, permission: permission, user: card.author }
         next if CardPermissionsUser.exists?(permissions_users_data)
 

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -64,4 +64,26 @@ namespace :permissions do
       puts "#{counter} cards permissions successfully updated"
     end
   end
+
+  desc 'update users with missing permissions for comments'
+  task create_missing_for_comments: :environment do
+    counter = 0
+
+    Comment.find_each do |comment|
+      Permission.comment_permissions.each do |permission|
+        permissions_users_data = { comment: comment, permission: permission, user: comment.author }
+        next if CommentPermissionsUser.exists?(permissions_users_data)
+
+        CommentPermissionsUser.create!(permissions_users_data)
+        counter += 1
+
+      rescue StandardError => e
+        puts "Failed to add #{permission.identifier} for#{comment.author.email}: #{e.message}"
+      end
+    end
+
+    if !Rails.env.test? && counter.positive?
+      puts "#{counter} comment permissions successfully updated"
+    end
+  end
 end

--- a/spec/factories/comment_permissions_user_factory.rb
+++ b/spec/factories/comment_permissions_user_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment_permissions_user do
+    user
+    permission
+    comment
+  end
+end

--- a/spec/graphql/mutations/comments/destroy_comment_spec.rb
+++ b/spec/graphql/mutations/comments/destroy_comment_spec.rb
@@ -4,15 +4,19 @@ require 'rails_helper'
 
 RSpec.describe Mutations::DestroyCommentMutation, type: :request do
   describe '.resolve' do
-    let(:author) { create(:user) }
-    let(:card) { create(:card, author: author) }
-    let(:comment) { create(:comment, author: author, card: card) }
+    let(:user) { create(:user) }
+    let(:comment) { create(:comment, author: user) }
+    let_it_be(:destroy_permission) { create(:permission, identifier: 'destroy_comment') }
     let(:request) { post '/graphql', params: { query: query(id: comment.id) } }
 
-    before { sign_in author }
+    before do
+      create(:comment_permissions_user, permission: destroy_permission,
+                                        user: user, comment: comment)
+    end
+    before { sign_in user }
 
     it 'deletes a comment' do
-      expect { request.to change { Comment.count }.by(-1) }
+      expect { request }.to change { Comment.count }.by(-1)
     end
 
     it 'returns a comment' do

--- a/spec/graphql/mutations/comments/like_comment_spec.rb
+++ b/spec/graphql/mutations/comments/like_comment_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Mutations::LikeCommentMutation, type: :request do
   describe '.resolve' do
     let(:author) { create(:user) }
     let(:card) { create(:card, author: author) }
-    let(:comment) { create(:comment, author: author, card: card) }
+    let!(:comment) { create(:comment, author: author, card: card) }
     let(:non_author) { create(:user) }
     let(:request) { post '/graphql', params: { query: query(id: comment.id) } }
 
     context 'when logged as not comment author' do
       before { sign_in non_author }
       it 'updates a comment' do
-        expect { request.to change { Comment.likes }.by(1) }
+        expect { request.to change { comment.likes }.by(1) }
       end
 
       it 'returns a comment' do
@@ -30,10 +30,12 @@ RSpec.describe Mutations::LikeCommentMutation, type: :request do
         )
       end
     end
+
     context 'when logged as author' do
       before { sign_in author }
+
       it 'doesn\'t update a comment' do
-        expect { request.to not_change { Comment.likes } }
+        expect { request }.not_to change { comment.likes }
       end
     end
   end

--- a/spec/graphql/mutations/comments/update_comment_spec.rb
+++ b/spec/graphql/mutations/comments/update_comment_spec.rb
@@ -4,32 +4,36 @@ require 'rails_helper'
 
 RSpec.describe Mutations::UpdateCommentMutation, type: :request do
   describe '.resolve' do
-    let(:author) { create(:user) }
-    let(:card) { create(:card, author: author) }
-    let(:comment) { create(:comment, author: author, card: card) }
+    let(:user) { create(:user) }
+    let(:comment) { create(:comment, author: user) }
+    let_it_be(:update_permission) { create(:permission, identifier: 'update_comment') }
     let(:request) { post '/graphql', params: { query: query(id: comment.id, content: 'Updated') } }
 
-    before { sign_in author }
+    before do
+      create(:comment_permissions_user, permission: update_permission,
+                                        user: user, comment: comment)
+    end
+
+    before { sign_in user }
 
     it 'updates a comment' do
       request
 
       expect(comment.reload).to have_attributes(
-        'author_id' => author.id,
+        'author_id' => user.id,
         'content' => 'Updated'
       )
     end
 
     it 'returns a comment' do
       request
-
       json = JSON.parse(response.body)
       data = json.dig('data', 'updateComment', 'comment')
 
       expect(data).to include(
         'id' => comment.id,
         'content' => 'Updated',
-        'author' => { 'id' => author.id.to_s }
+        'author' => { 'id' => user.id.to_s }
       )
     end
   end

--- a/spec/models/comment_permissions_user_spec.rb
+++ b/spec/models/comment_permissions_user_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CommentPermissionsUser, type: :model do
+  let_it_be(:comment_permissions_user) { create(:comment_permissions_user) }
+  let_it_be(:user) { build_stubbed(:user) }
+  let_it_be(:comment) { build_stubbed(:comment) }
+  let_it_be(:permission) { build_stubbed(:permission) }
+
+  context 'associations' do
+    it 'belongs to user' do
+      expect(comment_permissions_user).to respond_to(:user)
+    end
+
+    it 'belongs to permission' do
+      expect(comment_permissions_user).to respond_to(:permission)
+    end
+
+    it 'belongs to comment' do
+      expect(comment_permissions_user).to respond_to(:comment)
+    end
+  end
+
+  context 'validations' do
+    before do
+      create(:comment_permissions_user, permission: permission, user: user, comment: comment)
+    end
+
+    let(:with_uniq_comment) do
+      build_stubbed(:comment_permissions_user, user: user, permission: permission)
+    end
+    let(:with_uniq_user) do
+      create(:comment_permissions_user, permission: permission, comment: comment)
+    end
+    let(:with_uniq_permission) do
+      build_stubbed(:comment_permissions_user, user: user, comment: comment)
+    end
+    let(:not_uniq_permissions_user) do
+      build_stubbed(:comment_permissions_user, user: user,
+                                               comment: comment,
+                                               permission: permission)
+    end
+
+    it 'is valid when card is uniq' do
+      expect(with_uniq_comment).to be_valid
+    end
+
+    it 'is valid when user is uniq' do
+      expect(with_uniq_user).to be_valid
+    end
+
+    it 'is valid when permission is uniq' do
+      expect(with_uniq_permission).to be_valid
+    end
+
+    it 'is not valid when neither of user card or permission is uniq' do
+      expect(not_uniq_permissions_user).to be_invalid
+    end
+  end
+end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -34,12 +34,20 @@ RSpec.describe Permission, type: :model do
       expect(permission).to respond_to(:card_users)
     end
 
+    it 'has_many_comment_users' do
+      expect(permission).to respond_to(:comment_users)
+    end
+
     it 'has_many_board_permissions_users' do
       expect(permission).to respond_to(:board_permissions_users)
     end
 
     it 'has_many_card_permissions_users' do
       expect(permission).to respond_to(:card_permissions_users)
+    end
+
+    it 'has_many_comment_permissions_users' do
+      expect(permission).to respond_to(:comment_permissions_users)
     end
   end
 

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -67,15 +67,15 @@ RSpec.describe Permission, type: :model do
     end
   end
 
-  context '.author_permissions' do
-    let_it_be(:author_permission) { create(:permission, identifier: 'update_card') }
+  context '.card_permissions' do
+    let_it_be(:card_permission) { create(:permission, identifier: 'update_card') }
 
-    it 'returns permissions with author identifiers' do
-      expect(Permission.author_permissions).to include(author_permission)
+    it 'returns permissions with card identifiers' do
+      expect(Permission.card_permissions).to include(card_permission)
     end
 
-    it 'excludes permissions without author identifiers' do
-      expect(Permission.author_permissions).not_to include(permission)
+    it 'excludes permissions without card identifiers' do
+      expect(Permission.card_permissions).not_to include(permission)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,20 +37,28 @@ RSpec.describe User, type: :model do
       expect(user).to respond_to(:action_items)
     end
 
-    it 'has many board permissions users' do
-      expect(user).to respond_to(:board_permissions_users)
-    end
-
     it 'has many board_permissions' do
       expect(user).to respond_to(:board_permissions)
+    end
+
+    it 'has many card_permissions' do
+      expect(user).to respond_to(:card_permissions)
+    end
+
+    it 'has many comment_permissions' do
+      expect(user).to respond_to(:comment_permissions)
+    end
+
+    it 'has many board permissions users' do
+      expect(user).to respond_to(:board_permissions_users)
     end
 
     it 'has many card permissions users' do
       expect(user).to respond_to(:card_permissions_users)
     end
 
-    it 'has many card_permissions' do
-      expect(user).to respond_to(:card_permissions)
+    it 'has many comment permissions users' do
+      expect(user).to respond_to(:comment_permissions_users)
     end
   end
 
@@ -155,6 +163,24 @@ RSpec.describe User, type: :model do
       context 'when permission exists' do
         let_it_be(:permission) { create(:permission, identifier: 'some_identifier') }
         before { create(:card_permissions_user, user: user, card: card, permission: permission) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when permission does not exist' do
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with comment permissions' do
+      let_it_be(:comment) { build_stubbed(:comment) }
+      subject { user.allowed?('some_identifier', comment) }
+
+      context 'when permission exists' do
+        let_it_be(:permission) { create(:permission, identifier: 'some_identifier') }
+        before do
+          create(:comment_permissions_user, user: user, comment: comment, permission: permission)
+        end
 
         it { is_expected.to be true }
       end

--- a/spec/operations/boards/boards_build_permissions_spec.rb
+++ b/spec/operations/boards/boards_build_permissions_spec.rb
@@ -4,41 +4,37 @@ require 'rails_helper'
 
 RSpec.describe Boards::BuildPermissions do
   subject(:build_permissions) do
-    described_class.new(resource, user).call(identifiers_scope: identifiers_scope)
+    described_class.new(board, user).call(identifiers_scope: identifiers_scope)
   end
 
   let(:user) { create(:user) }
+  let(:board) { create(:board) }
   let!(:permission) { create(:permission, identifier: 'edit_board') }
 
-  context 'valid identifiers scope' do
+  context 'with valid identifiers scope' do
     let(:identifiers_scope) { 'creator' }
 
-    context 'for board' do
-      let(:resource) { create(:board) }
+    it { is_expected.to be_success }
 
-      it { is_expected.to be_success }
+    it 'builds permission to board' do
+      build_permissions
+      expect(board.board_permissions_users.first.permission).to eq(permission)
+    end
 
-      it 'builds permission to board' do
-        build_permissions
-        expect(resource.board_permissions_users.first.permission).to eq(permission)
-      end
-
-      it 'builds permission to user' do
-        build_permissions
-        expect(resource.board_permissions_users.first.user).to eq(user)
-      end
+    it 'builds permission to user' do
+      build_permissions
+      expect(board.board_permissions_users.first.user).to eq(user)
     end
   end
 
-  context 'invalid identifiers scope' do
+  context 'with invalid identifiers scope' do
     let(:identifiers_scope) { 'invalid' }
-    let(:resource) { create(:board) }
 
     it { is_expected.to be_failure }
 
     it 'does not build permissions_users' do
       build_permissions
-      expect(resource.board_permissions_users).to be_empty
+      expect(board.board_permissions_users).to be_empty
     end
   end
 end

--- a/spec/operations/boards/cards/cards_build_permissions_spec.rb
+++ b/spec/operations/boards/cards/cards_build_permissions_spec.rb
@@ -4,41 +4,37 @@ require 'rails_helper'
 
 RSpec.describe Boards::Cards::BuildPermissions do
   subject(:build_permissions) do
-    described_class.new(resource, user).call(identifiers_scope: identifiers_scope)
+    described_class.new(card, user).call(identifiers_scope: identifiers_scope)
   end
 
   let(:user) { create(:user) }
+  let(:card) { create(:card) }
   let!(:permission) { create(:permission, identifier: 'update_card') }
 
-  context 'valid identifiers scope' do
+  context 'with valid identifiers scope' do
     let(:identifiers_scope) { 'card' }
 
-    context 'for card' do
-      let(:resource) { create(:card) }
+    it { is_expected.to be_success }
 
-      it { is_expected.to be_success }
+    it 'builds permission to card' do
+      build_permissions
+      expect(card.card_permissions_users.first.permission).to eq(permission)
+    end
 
-      it 'builds permission to card' do
-        build_permissions
-        expect(resource.card_permissions_users.first.permission).to eq(permission)
-      end
-
-      it 'builds permission to user' do
-        build_permissions
-        expect(resource.card_permissions_users.first.user).to eq(user)
-      end
+    it 'builds permission to user' do
+      build_permissions
+      expect(card.card_permissions_users.first.user).to eq(user)
     end
   end
 
-  context 'invalid identifiers scope' do
+  context 'with invalid identifiers scope' do
     let(:identifiers_scope) { 'invalid' }
-    let(:resource) { create(:board) }
 
     it { is_expected.to be_failure }
 
     it 'does not build permissions_users' do
       build_permissions
-      expect(resource.board_permissions_users).to be_empty
+      expect(card.card_permissions_users).to be_empty
     end
   end
 end

--- a/spec/operations/boards/cards/cards_build_permissions_spec.rb
+++ b/spec/operations/boards/cards/cards_build_permissions_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Boards::Cards::BuildPermissions do
   let!(:permission) { create(:permission, identifier: 'update_card') }
 
   context 'valid identifiers scope' do
-    let(:identifiers_scope) { 'author' }
+    let(:identifiers_scope) { 'card' }
 
     context 'for card' do
       let(:resource) { create(:card) }

--- a/spec/operations/boards/cards/comments/comments_build_permissions_spec.rb
+++ b/spec/operations/boards/cards/comments/comments_build_permissions_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Boards::Cards::Comments::BuildPermissions do
+  subject(:build_permissions) do
+    described_class.new(comment, user).call(identifiers_scope: identifiers_scope)
+  end
+
+  let(:user) { create(:user) }
+  let(:comment) { create(:comment) }
+  let!(:permission) { create(:permission, identifier: 'update_comment') }
+
+  context 'with valid identifiers scope' do
+    let(:identifiers_scope) { 'comment' }
+
+    it { is_expected.to be_success }
+
+    it 'builds permission to comment' do
+      build_permissions
+      expect(comment.comment_permissions_users.first.permission).to eq(permission)
+    end
+
+    it 'builds permission to user' do
+      build_permissions
+      expect(comment.comment_permissions_users.first.user).to eq(user)
+    end
+  end
+
+  context 'with invalid identifiers scope' do
+    let(:identifiers_scope) { 'invalid' }
+
+    it { is_expected.to be_failure }
+
+    it 'does not build permissions_users' do
+      build_permissions
+      expect(comment.comment_permissions_users).to be_empty
+    end
+  end
+end

--- a/spec/operations/boards/cards/comments/create_comment_spec.rb
+++ b/spec/operations/boards/cards/comments/create_comment_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Boards::Cards::Comments::Create do
+  subject { described_class.new(user).call(comment_params) }
+  let_it_be(:user) { create(:user) }
+  let_it_be(:card) { create(:card) }
+  let_it_be(:permission) { create(:permission, identifier: 'update_comment') }
+  let(:comment_params) { attributes_for(:comment).merge(author: user, card: card) }
+
+  it 'creates a comment' do
+    expect { subject }.to change { card.comments.count }.by(1)
+  end
+
+  it 'adds permission to user' do
+    expect { subject }.to change(user.comment_permissions, :count).by(1)
+  end
+
+  it 'returns a comment' do
+    expect(subject.value!).to eq Comment.find_by(author: user)
+  end
+end

--- a/spec/policies/board_policy_spec.rb
+++ b/spec/policies/board_policy_spec.rb
@@ -164,7 +164,25 @@ RSpec.describe BoardPolicy do
       it { is_expected.to eq true }
     end
 
-    context 'when user does not have update_board permission' do
+    context 'when user does not have create_cards permission' do
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#create_comments?' do
+    let_it_be(:create_comments_permission) { create(:permission, identifier: 'create_comments') }
+    subject { policy.apply(:create_comments?) }
+
+    context 'when user has create_comments permission' do
+      let!(:board_permissions_user) do
+        create(:board_permissions_user, permission: create_comments_permission,
+                                        user: user, board: board)
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when user does not have create_comments permission' do
       it { is_expected.to eq false }
     end
   end

--- a/spec/policies/card_policy_spec.rb
+++ b/spec/policies/card_policy_spec.rb
@@ -8,25 +8,6 @@ RSpec.describe CardPolicy do
   let_it_be(:card) { create(:card, board: board) }
   let(:policy) { described_class.new(card, user: user) }
 
-  describe '#create?' do
-    subject { policy.apply(:create?) }
-
-    context 'with permission' do
-      let_it_be(:create_cards_permission) { create(:permission, identifier: 'create_cards') }
-      before do
-        create(:board_permissions_user, board: board,
-                                        user: user,
-                                        permission: create_cards_permission)
-      end
-
-      it { is_expected.to eq true }
-    end
-
-    context 'without permission' do
-      it { is_expected.to eq false }
-    end
-  end
-
   describe '#destroy?' do
     subject { policy.apply(:destroy?) }
 

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CommentPolicy do
+  let_it_be(:user) { create(:user) }
+  let_it_be(:board) { create(:board) }
+  let_it_be(:card) { create(:card, board: board) }
+  let_it_be(:comment) { create(:comment, card: card) }
+  let(:policy) { described_class.new(comment, user: user) }
+
+  describe '#create?' do
+    subject { policy.apply(:create?) }
+
+    context 'with permission' do
+      let_it_be(:create_comments_permission) { create(:permission, identifier: 'create_comments') }
+      before do
+        create(:board_permissions_user, board: board,
+                                        user: user,
+                                        permission: create_comments_permission)
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'without permission' do
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#destroy?' do
+    subject { policy.apply(:destroy?) }
+
+    context 'with permission' do
+      let(:destroy_comment_permission) { create(:permission, identifier: 'destroy_comment') }
+      before do
+        create(:comment_permissions_user, comment: comment,
+                                          user: user,
+                                          permission: destroy_comment_permission)
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'without permission' do
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#update?' do
+    subject { policy.apply(:update?) }
+
+    context 'with permission' do
+      let_it_be(:update_comment_permission) { create(:permission, identifier: 'update_comment') }
+      before do
+        create(:comment_permissions_user, comment: comment,
+                                          user: user,
+                                          permission: update_comment_permission)
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'without permission' do
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#like?' do
+    subject { policy.apply(:like?) }
+
+    context 'when user is not a comment author' do
+      it { is_expected.to eq true }
+    end
+
+    context 'when user is a comment author' do
+      before { comment.update!(author: user) }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#user_not_author?' do
+    subject { policy.apply(:user_not_author?) }
+
+    context 'when user is not comment author' do
+      let(:not_author) { create(:user) }
+      let(:policy) { described_class.new(comment, user: not_author) }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when user is a comment author' do
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#find_board' do
+    subject { policy.apply(:find_board) }
+
+    it { is_expected.to eq board }
+  end
+end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe CommentPolicy do
   let_it_be(:comment) { create(:comment, card: card) }
   let(:policy) { described_class.new(comment, user: user) }
 
-  describe '#create?' do
-    subject { policy.apply(:create?) }
+  describe '#update?' do
+    subject { policy.apply(:update?) }
 
     context 'with permission' do
-      let_it_be(:create_comments_permission) { create(:permission, identifier: 'create_comments') }
+      let_it_be(:update_comment_permission) { create(:permission, identifier: 'update_comment') }
       before do
-        create(:board_permissions_user, board: board,
-                                        user: user,
-                                        permission: create_comments_permission)
+        create(:comment_permissions_user, comment: comment,
+                                          user: user,
+                                          permission: update_comment_permission)
       end
 
       it { is_expected.to eq true }
@@ -37,25 +37,6 @@ RSpec.describe CommentPolicy do
         create(:comment_permissions_user, comment: comment,
                                           user: user,
                                           permission: destroy_comment_permission)
-      end
-
-      it { is_expected.to eq true }
-    end
-
-    context 'without permission' do
-      it { is_expected.to eq false }
-    end
-  end
-
-  describe '#update?' do
-    subject { policy.apply(:update?) }
-
-    context 'with permission' do
-      let_it_be(:update_comment_permission) { create(:permission, identifier: 'update_comment') }
-      before do
-        create(:comment_permissions_user, comment: comment,
-                                          user: user,
-                                          permission: update_comment_permission)
       end
 
       it { is_expected.to eq true }
@@ -93,11 +74,5 @@ RSpec.describe CommentPolicy do
     context 'when user is a comment author' do
       it { is_expected.to eq false }
     end
-  end
-
-  describe '#find_board' do
-    subject { policy.apply(:find_board) }
-
-    it { is_expected.to eq board }
   end
 end

--- a/spec/tasks/permissions_spec.rb
+++ b/spec/tasks/permissions_spec.rb
@@ -19,20 +19,18 @@ RSpec.describe 'permissions.rake' do
   describe 'create_missing_permissions' do
     let(:user) { create(:user) }
     let_it_be(:board) { create(:board) }
-    let_it_be(:creator_permission) { create(:permission, identifier: 'destroy_board') }
-    let_it_be(:member_permission) { create(:permission, identifier: 'toggle_ready_status') }
-    let_it_be(:author_card_permission) { create(:permission, identifier: 'update_card') }
     let_it_be(:other_permission) { create(:permission) }
 
     context 'for boards' do
       let_it_be(:task_name) { 'permissions:create_missing_for_boards' }
 
       context 'with creator membership' do
+        let_it_be(:creator_permission) { create(:permission, identifier: 'destroy_board') }
         before { create(:membership, user: user, board: board, role: 'creator') }
 
         it 'connects to missing creator permissions' do
           run_task
-          expect(user.board_permissions).to include(creator_permission, member_permission)
+          expect(user.board_permissions).to include(creator_permission)
         end
 
         it 'does not connect to non creator_permissions' do
@@ -42,6 +40,8 @@ RSpec.describe 'permissions.rake' do
       end
 
       context 'with members' do
+        let_it_be(:member_permission) { create(:permission, identifier: 'toggle_ready_status') }
+
         before { create(:membership, user: user, board: board, role: 'member') }
 
         it 'connects to missing member permissions' do
@@ -51,23 +51,40 @@ RSpec.describe 'permissions.rake' do
 
         it 'does not connect to non member_permissions' do
           run_task
-          expect(user.board_permissions).not_to include(other_permission, creator_permission)
+          expect(user.board_permissions).not_to include(other_permission)
         end
       end
     end
 
     context 'for cards' do
+      let_it_be(:card_permission) { create(:permission, identifier: 'update_card') }
       let!(:card) { create(:card, author: user) }
       let_it_be(:task_name) { 'permissions:create_missing_for_cards' }
 
-      it 'connects to missing card permissions' do
+      it 'builds missing card permissions' do
         run_task
-        expect(user.card_permissions).to include(author_card_permission)
+        expect(user.card_permissions).to include(card_permission)
       end
 
-      it 'does not connect to non card permissions' do
+      it 'does not build non card permissions' do
         run_task
         expect(user.card_permissions).not_to include(other_permission)
+      end
+    end
+
+    context 'for comments' do
+      let_it_be(:comment_permission) { create(:permission, identifier: 'update_comment') }
+      let!(:comment) { create(:comment, author: user) }
+      let_it_be(:task_name) { 'permissions:create_missing_for_comments' }
+
+      it 'builds missing comment permissions' do
+        run_task
+        expect(user.comment_permissions).to include(comment_permission)
+      end
+
+      it 'does not build non card permissions' do
+        run_task
+        expect(user.comment_permissions).not_to include(other_permission)
       end
     end
   end


### PR DESCRIPTION
- CardPermissionsUser model created to build connection with permissions, users, cards
- Operations to create a comment and build comment permissions added
- Comment policy updated
- Author permissions renamed to Card permissions
- Tests added and updated
- Rake task to update existing records added and seeds updated

For production please run
- `rails db:migrate`
- `rails db:seed` for adding new permissions and running rake tasks for building missing ones for comments
