### PR TITLE
Action items permissions

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -4,8 +4,11 @@ class Permission < ApplicationRecord
   CREATOR_IDENTIFIERS = %w[view_private_board edit_board update_board get_suggestions
                            destroy_board continue_board create_cards invite_members
                            toggle_ready_status destroy_membership destroy_any_card
-                           like_card].freeze
-  MEMBER_IDENTIFIERS = %w[view_private_board create_cards toggle_ready_status like_card].freeze
+                           like_card create_action_items update_action_items destroy_action_items
+                           move_action_items close_action_items complete_action_items
+                           reopen_action_items].freeze
+  MEMBER_IDENTIFIERS = %w[view_private_board create_cards toggle_ready_status like_card
+                          create_action_items].freeze
   AUTHOR_IDENTIFIERS = %w[update_card destroy_card].freeze
 
   has_many :board_permissions_users, dependent: :destroy

--- a/app/policies/action_item_policy.rb
+++ b/app/policies/action_item_policy.rb
@@ -4,42 +4,34 @@ class ActionItemPolicy < ApplicationPolicy
   authorize :board, allow_nil: true
 
   def create?
-    check?(:user_is_member?)
+    user.allowed?('create_action_items', board)
   end
 
   def update?
-    check?(:user_is_creator?)
+    user.allowed?('update_action_items', current_board)
   end
 
   def destroy?
-    check?(:user_is_creator?)
+    user.allowed?('destroy_action_items', current_board)
   end
 
   def move?
-    check?(:user_is_creator?) && record.pending?
+    user.allowed?('move_action_items', current_board) && record.pending?
   end
 
   def close?
-    check?(:user_is_creator?) && record.may_close?
+    user.allowed?('close_action_items', current_board) && record.may_close?
   end
 
   def complete?
-    check?(:user_is_creator?) && record.may_complete?
+    user.allowed?('complete_action_items', current_board) && record.may_complete?
   end
 
   def reopen?
-    check?(:user_is_creator?) && record.may_reopen?
+    user.allowed?('reopen_action_items', current_board) && record.may_reopen?
   end
 
-  def user_is_creator?
-    if board
-      board.memberships.exists?(user_id: user.id, role: 'creator')
-    else
-      record.board.memberships.exists?(user_id: user.id, role: 'creator')
-    end
-  end
-
-  def user_is_member?
-    board.memberships.where(user_id: user.id).exists?
+  def current_board
+    board || record.board
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,7 +58,14 @@ permissions_data = {
   destroy_any_card: 'User can delete any card on a board',
   destroy_card: 'User can delete a card on a board',
   update_card: 'User can update a card on a board',
-  like_card: 'User can like a card on a board'
+  like_card: 'User can like a card on a board',
+  create_action_items: 'User can create action items on a board',
+  update_action_items: 'User can destroy action items on a board',
+  destroy_action_items: 'User can destroy action items on a board',
+  move_action_items: 'User can move action items',
+  close_action_items: 'User can close action items',
+  complete_action_items: 'User can mark action items as complete',
+  reopen_action_items: 'User can reopen action items'
 }
 
 errors = []

--- a/spec/controllers/action_items_controller_spec.rb
+++ b/spec/controllers/action_items_controller_spec.rb
@@ -5,17 +5,9 @@ require 'rails_helper'
 RSpec.describe ActionItemsController do
   let_it_be(:board) { create(:board) }
   let_it_be(:action_item) { create(:action_item, board: board) }
-  let_it_be(:creator) { create(:user) }
+  let_it_be(:user) { create(:user) }
   let_it_be(:closed_action_item) do
-    create(:action_item, status: 'closed', board: board, author: creator)
-  end
-  let_it_be(:member) { create(:user) }
-  let_it_be(:not_member) { create(:user) }
-  let_it_be(:creatorship) do
-    create(:membership, board: board, user: creator, role: 'creator')
-  end
-  let_it_be(:membership) do
-    create(:membership, board: board, user: member, role: 'member')
+    create(:action_item, status: 'closed', board: board, author: user)
   end
 
   before { bypass_rescue }
@@ -31,28 +23,26 @@ RSpec.describe ActionItemsController do
   describe 'PUT #close' do
     subject(:response) { put :close, params: params }
     let_it_be(:params) { { id: action_item.id } }
+    let(:close_permission) { create(:permission, identifier: 'close_action_items') }
 
     context 'when user is not logged in' do
       it { is_expected.to have_http_status(:redirect) }
     end
 
     context 'when user is logged_in' do
-      context 'user is not a board member' do
-        before { login_as not_member }
+      before { login_as user }
+
+      context 'without permission' do
         it 'raises error ActionPolicy::Unauthorized' do
           expect { subject }.to raise_error(ActionPolicy::Unauthorized)
         end
       end
 
-      context 'user is a board member' do
-        before { login_as member }
-        it 'raises error ActionPolicy::Unauthorized' do
-          expect { subject }.to raise_error(ActionPolicy::Unauthorized)
+      context 'with permission' do
+        before do
+          create(:board_permissions_user, permission: close_permission, user: user, board: board)
         end
-      end
 
-      context 'user is the board creator' do
-        before { login_as creator }
         it { is_expected.to have_http_status(:redirect) }
       end
     end
@@ -61,28 +51,26 @@ RSpec.describe ActionItemsController do
   describe 'PUT #complete' do
     subject(:response) { put :complete, params: params }
     let_it_be(:params) { { id: action_item.id } }
+    let(:complete_permission) { create(:permission, identifier: 'complete_action_items') }
 
     context 'when user is not logged in' do
       it { is_expected.to have_http_status(:redirect) }
     end
 
     context 'when user is logged_in' do
-      context 'user is not a board member' do
-        before { login_as not_member }
+      before { login_as user }
+
+      context 'without permission' do
         it 'raises error ActionPolicy::Unauthorized' do
           expect { subject }.to raise_error(ActionPolicy::Unauthorized)
         end
       end
 
-      context 'user is a board member' do
-        before { login_as member }
-        it 'raises error ActionPolicy::Unauthorized' do
-          expect { subject }.to raise_error(ActionPolicy::Unauthorized)
+      context 'with permission' do
+        before do
+          create(:board_permissions_user, permission: complete_permission, user: user, board: board)
         end
-      end
 
-      context 'user is the board creator' do
-        before { login_as creator }
         it { is_expected.to have_http_status(:redirect) }
       end
     end
@@ -91,28 +79,26 @@ RSpec.describe ActionItemsController do
   describe 'PUT #reopen' do
     subject(:response) { put :reopen, params: params }
     let_it_be(:params) { { id: closed_action_item.id } }
+    let(:reopen_permission) { create(:permission, identifier: 'reopen_action_items') }
 
     context 'when user is not logged in' do
       it { is_expected.to have_http_status(:redirect) }
     end
 
     context 'when user is logged_in' do
-      context 'user is not a board member' do
-        before { login_as not_member }
+      before { login_as user }
+
+      context 'without permission' do
         it 'raises error ActionPolicy::Unauthorized' do
           expect { subject }.to raise_error(ActionPolicy::Unauthorized)
         end
       end
 
-      context 'user is a board member' do
-        before { login_as member }
-        it 'raises error ActionPolicy::Unauthorized' do
-          expect { subject }.to raise_error(ActionPolicy::Unauthorized)
+      context 'with permission' do
+        before do
+          create(:board_permissions_user, permission: reopen_permission, user: user, board: board)
         end
-      end
 
-      context 'user is the board creator' do
-        before { login_as creator }
         it { is_expected.to have_http_status(:redirect) }
       end
     end

--- a/spec/graphql/mutations/action_items/add_action_item_spec.rb
+++ b/spec/graphql/mutations/action_items/add_action_item_spec.rb
@@ -4,30 +4,39 @@ require 'rails_helper'
 
 RSpec.describe Mutations::AddActionItemMutation, type: :request do
   describe '.resolve' do
-    let_it_be(:author) { create(:user) }
+    let_it_be(:user) { create(:user) }
     let_it_be(:board) { create(:board) }
+    let(:create_permission) { create(:permission, identifier: 'create_action_items') }
     let(:request) { post '/graphql', params: { query: query(board_slug: board.slug) } }
 
-    let_it_be(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
+    before { sign_in user }
+
+    context 'with permission' do
+      before do
+        create(:board_permissions_user, permission: create_permission, user: user, board: board)
+      end
+
+      it 'creates an action item' do
+        expect { request }.to change { ActionItem.count }.by(1)
+      end
+
+      it 'returns an action item' do
+        request
+        json = JSON.parse(response.body)
+        data = json.dig('data', 'addActionItem', 'actionItem')
+
+        expect(data).to include(
+          'id' => be_present,
+          'body' => 'Some text',
+          'author' => { 'id' => user.id.to_s }
+        )
+      end
     end
 
-    before { sign_in author }
-
-    it 'creates an action item' do
-      expect { request }.to change { ActionItem.count }.by(1)
-    end
-
-    it 'returns an action item' do
-      request
-      json = JSON.parse(response.body)
-      data = json.dig('data', 'addActionItem', 'actionItem')
-
-      expect(data).to include(
-        'id' => be_present,
-        'body' => 'Some text',
-        'author' => { 'id' => author.id.to_s }
-      )
+    context 'without permission' do
+      it 'does not create an action item' do
+        expect { request }.to_not change { ActionItem.count }
+      end
     end
   end
 

--- a/spec/graphql/mutations/action_items/close_action_item_spec.rb
+++ b/spec/graphql/mutations/action_items/close_action_item_spec.rb
@@ -4,26 +4,23 @@ require 'rails_helper'
 
 RSpec.describe Mutations::CloseActionItemMutation, type: :request do
   describe '.resolve' do
-    let_it_be(:author) { create(:user) }
-    let_it_be(:non_author) { create(:user) }
+    let_it_be(:user) { create(:user) }
     let_it_be(:old_board) { create(:board) }
     let_it_be(:board) { create(:board) }
     let_it_be(:action_item) { create(:action_item, board: old_board) }
-
+    let(:close_permission) { create(:permission, identifier: 'close_action_items') }
     let(:request) do
       post '/graphql', params: { query: query(id: action_item.id,
                                               board_slug: board.slug) }
     end
-    let_it_be(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
-    end
 
-    let_it_be(:old_creatorship) do
-      create(:membership, board: old_board, user: author, role: 'creator')
-    end
+    before { sign_in user }
 
-    context 'when logged as author' do
-      before { sign_in author }
+    context 'with permission' do
+      before do
+        create(:board_permissions_user, permission: close_permission, user: user, board: board)
+      end
+
       it 'updates an action_item' do
         expect { request }.to change { action_item.reload.status }.to 'closed'
       end
@@ -39,9 +36,8 @@ RSpec.describe Mutations::CloseActionItemMutation, type: :request do
       end
     end
 
-    context 'when logged as non-author' do
-      before { sign_in non_author }
-      it 'updates an action item' do
+    context 'without permission' do
+      it 'does not update an action item' do
         expect { request }.to_not change { action_item.reload.status }
       end
     end

--- a/spec/graphql/mutations/action_items/complete_action_item_spec.rb
+++ b/spec/graphql/mutations/action_items/complete_action_item_spec.rb
@@ -4,26 +4,23 @@ require 'rails_helper'
 
 RSpec.describe Mutations::CompleteActionItemMutation, type: :request do
   describe '.resolve' do
-    let_it_be(:author) { create(:user) }
-    let_it_be(:non_author) { create(:user) }
+    let_it_be(:user) { create(:user) }
     let_it_be(:old_board) { create(:board) }
     let_it_be(:board) { create(:board) }
     let_it_be(:action_item) { create(:action_item, board: old_board) }
-
+    let(:complete_permission) { create(:permission, identifier: 'complete_action_items') }
     let(:request) do
       post '/graphql', params: { query: query(id: action_item.id,
                                               board_slug: board.slug) }
     end
-    let_it_be(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
-    end
 
-    let_it_be(:old_creatorship) do
-      create(:membership, board: old_board, user: author, role: 'creator')
-    end
+    before { sign_in user }
 
-    context 'when logged as author' do
-      before { sign_in author }
+    context 'with permission' do
+      before do
+        create(:board_permissions_user, permission: complete_permission, user: user, board: board)
+      end
+
       it 'updates an action_item' do
         expect { request }.to change { action_item.reload.status }.to 'done'
       end
@@ -39,9 +36,8 @@ RSpec.describe Mutations::CompleteActionItemMutation, type: :request do
       end
     end
 
-    context 'when logged as non-author' do
-      before { sign_in non_author }
-      it 'updates an action item' do
+    context 'without permission' do
+      it 'does not update an action item' do
         expect { request }.to_not change { action_item.reload.status }
       end
     end

--- a/spec/graphql/mutations/action_items/reopen_action_item_spec.rb
+++ b/spec/graphql/mutations/action_items/reopen_action_item_spec.rb
@@ -4,26 +4,23 @@ require 'rails_helper'
 
 RSpec.describe Mutations::ReopenActionItemMutation, type: :request do
   describe '.resolve' do
-    let_it_be(:author) { create(:user) }
-    let_it_be(:non_author) { create(:user) }
+    let_it_be(:user) { create(:user) }
     let_it_be(:old_board) { create(:board) }
     let_it_be(:board) { create(:board) }
     let_it_be(:action_item) { create(:action_item, board: old_board, status: 'closed') }
-
+    let(:reopen_permission) { create(:permission, identifier: 'reopen_action_items') }
     let(:request) do
       post '/graphql', params: { query: query(id: action_item.id,
                                               board_slug: board.slug) }
     end
-    let_it_be(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
-    end
 
-    let_it_be(:old_creatorship) do
-      create(:membership, board: old_board, user: author, role: 'creator')
-    end
+    before { sign_in user }
 
-    context 'when logged as author' do
-      before { sign_in author }
+    context 'with permission' do
+      before do
+        create(:board_permissions_user, permission: reopen_permission, user: user, board: board)
+      end
+
       it 'updates an action_item' do
         expect { request }.to change { action_item.reload.status }.to 'pending'
       end
@@ -39,8 +36,7 @@ RSpec.describe Mutations::ReopenActionItemMutation, type: :request do
       end
     end
 
-    context 'when logged as non-author' do
-      before { sign_in non_author }
+    context 'without permission' do
       it 'updates an action item' do
         expect { request }.to_not change { action_item.reload.status }
       end

--- a/spec/graphql/mutations/action_items/update_action_item_spec.rb
+++ b/spec/graphql/mutations/action_items/update_action_item_spec.rb
@@ -8,13 +8,15 @@ RSpec.describe Mutations::UpdateActionItemMutation, type: :request do
     let!(:board) { create(:board) }
     let!(:new_assignee) { create(:user) }
     let!(:action_item) { create(:action_item, board: board, assignee: author) }
+    let(:update_permission) { create(:permission, identifier: 'update_action_items') }
     let(:request) do
       post '/graphql', params: { query: query(id: action_item.id,
                                               body: 'New body',
                                               assignee_id: new_assignee.id) }
     end
-    let!(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
+
+    before do
+      create(:board_permissions_user, permission: update_permission, user: author, board: board)
     end
     before { sign_in author }
 


### PR DESCRIPTION
-  ActionItemPolicy updated
-  Permissions list updated with action items permissions for boards
-  Tests added and updated

For production please run

-  rails db:seed for adding new permissions and running rake task for building missing permissions for action items
