### PR TITLE
Add like permissions on card creation

### DIFF
--- a/app/operations/boards/cards/build_permissions.rb
+++ b/app/operations/boards/cards/build_permissions.rb
@@ -18,14 +18,27 @@ module Boards
           return Failure('Unknown permissions identifiers scope provided')
         end
 
-        permissions_data = Permission.public_send(
+        permissions_data = build_author_permissions(user.id, identifiers_scope: identifiers_scope)
+        like_permissions_data = build_like_permission(card.board.users.where.not(id: user.id))
+
+        card.card_permissions_users.build(permissions_data + like_permissions_data)
+        Success()
+      end
+
+      def build_author_permissions(user_id, identifiers_scope:)
+        Permission.public_send(
           "#{identifiers_scope}_permissions"
         ).map do |permission|
-          { permission_id: permission.id, user_id: user.id }
+          { permission_id: permission.id, user_id: user_id }
         end
+      end
 
-        card.card_permissions_users.build(permissions_data)
-        Success()
+      def build_like_permission(users)
+        like_permission = Permission.find_by(identifier: 'like_card')
+
+        users.map do |user|
+          { permission_id: like_permission.id, user_id: user.id }
+        end
       end
     end
   end

--- a/spec/operations/boards/cards/cards_build_permissions_spec.rb
+++ b/spec/operations/boards/cards/cards_build_permissions_spec.rb
@@ -37,4 +37,21 @@ RSpec.describe Boards::Cards::BuildPermissions do
       expect(card.card_permissions_users).to be_empty
     end
   end
+
+  context 'like_card permission' do
+    let(:board) { create(:board) }
+    let(:other_user) { create(:user) }
+
+    before do
+      board.users << other_user
+    end
+
+    it 'builds permissions' do
+      like_permission = card.card_permissions_users.select do |permission|
+        permission.user_id == other_user.id
+      end
+
+      expect(like_permission).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
When the card was created, users were not given permission to like them.
Added adding permissions on the card creation step.