### PR TITLE
Bump bundler from 2.0.2 to 2.2.25

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,4 +512,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.23
+   2.2.25

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         PG_MAJOR: '11'
         NODE_MAJOR: '12'
         YARN_VERSION: '1.19.1'
-        BUNDLER_VERSION: '2.0.2'
+        BUNDLER_VERSION: '2.2.25'
     image: example-dev:1.0.0
     tmpfs:
       - /tmp


### PR DESCRIPTION
fix for the AWS deploy action:
```ruby
Warning: the running version of Bundler (2.0.2) is older than the version that created the lockfile (2.2.23). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
You are trying to install in deployment mode after changing your Gemfile. Run `bundle install` elsewhere and add the updated Gemfile.lock to version control.
```