### PR TITLE
Stop using role from membership

### DIFF
--- a/app/controllers/api/v1/boards_controller.rb
+++ b/app/controllers/api/v1/boards_controller.rb
@@ -63,7 +63,7 @@ module API
         @board = Board.new(board_params)
         authorize! @board, to: :create?
 
-        @board.memberships.build(user_id: current_user.id, role: 'creator')
+        @board.memberships.build(user_id: current_user.id)
         result = Boards::BuildPermissions.new(@board, current_user)
                                          .call(identifiers_scope: 'creator')
 

--- a/app/graphql/types/membership_type.rb
+++ b/app/graphql/types/membership_type.rb
@@ -3,7 +3,6 @@
 module Types
   class MembershipType < Types::BaseObject
     field :id, Int, null: false
-    field :role, String, null: false
     field :ready, Boolean, null: false
     field :user, Types::UserType, null: false
     field :board, Types::BoardType, null: false

--- a/app/javascript/components/card-table.jsx
+++ b/app/javascript/components/card-table.jsx
@@ -11,9 +11,9 @@ import {BoardColumnHidden} from './board-column-hidden';
 const CardTable = ({
   actionItems,
   cardsByType,
-  creators,
   initPrevItems,
   user,
+  userIsCreator,
   users,
   previousBoardSlug
 }) => {
@@ -55,7 +55,7 @@ const CardTable = ({
     return content;
   };
 
-  user.isCreator = creators.includes(user.id);
+  user.isCreator = userIsCreator;
   return (
     <Provider>
       <BoardSlugContext.Provider value={window.location.pathname.split('/')[2]}>

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -16,7 +16,7 @@ class Board < ApplicationRecord
   scope :member_boards, lambda { |user|
     where.not(id: Board.select(:previous_board_id).where.not(previous_board_id: nil))
          .joins(board_permissions_users: :permission)
-         .where(permissions: { identifier: :toggle_ready_status },
+         .where(permissions: { identifier: Permission::MASTER_MEMBER_ID },
                 board_permissions_users: { user_id: user.id })
          .order(created_at: :desc)
   }
@@ -24,7 +24,7 @@ class Board < ApplicationRecord
   scope :creator_boards, lambda { |user|
     where.not(id: Board.select(:previous_board_id).where.not(previous_board_id: nil))
          .joins(board_permissions_users: :permission)
-         .where(permissions: { identifier: :destroy_board },
+         .where(permissions: { identifier: Permission::MASTER_CREATOR_ID },
                 board_permissions_users: { user_id: user.id })
          .order(created_at: :desc)
   }

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -5,5 +5,5 @@ class Membership < ApplicationRecord
   belongs_to :board, counter_cache: :users_count
   validates_uniqueness_of :user_id, scope: [:board_id]
 
-  enum role: { creator: 'creator', member: 'member', admin: 'admin', host: 'host' }
+  self.ignored_columns = ['role']
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -12,6 +12,8 @@ class Permission < ApplicationRecord
   CARD_IDENTIFIERS = %w[update_card destroy_card].freeze
   COMMENT_IDENTIFIERS = %w[update_comment destroy_comment].freeze
   LIKE_IDENTIFIERS = %w[like_comment like_card].freeze
+  MASTER_CREATOR_ID = :destroy_board
+  MASTER_MEMBER_ID = :toggle_ready_status
 
   has_many :board_permissions_users, dependent: :destroy
   has_many :board_users, through: :board_permissions_users, source: :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,12 @@ class User < ApplicationRecord
                                                             permission: permission).any?
   end
 
+  def creator?(board)
+    board_permissions_users
+      .exists?(permission: Permission.find_by_identifier(Permission::MASTER_CREATOR_ID),
+               board: board)
+  end
+
   private
 
   def new_user_settings(info)

--- a/app/operations/boards/invite_users.rb
+++ b/app/operations/boards/invite_users.rb
@@ -11,11 +11,11 @@ module Boards
     end
 
     def call
-      users_data = users.map { |user| { role: 'member', user_id: user.id } }
+      users_data = users.map { |user| { user_id: user.id } }
       memberships = board.memberships.build(users_data)
 
-      @users.find_each do |user|
-        BuildPermissions.new(@board, user).call(identifiers_scope: 'member')
+      users.find_each do |user|
+        BuildPermissions.new(board, user).call(identifiers_scope: 'member')
       end
 
       board.save

--- a/app/serializers/membership_serializer.rb
+++ b/app/serializers/membership_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MembershipSerializer < ActiveModel::Serializer
-  attributes :id, :role, :ready
+  attributes :id, :ready
 
   belongs_to :user
 end

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -44,9 +44,9 @@
   action_items: @action_items,
   board: @board.as_json,
   cards_by_type: @cards_by_type,
-  creators: @board_creators,
   init_prev_items: @previous_action_items || [],
   user: current_user.as_json,
+  user_is_creator: current_user.creator?(@board),
   users: @users,
   previous_board_slug: @previous_board_slug
 })

--- a/db/migrate/20201225131656_populate_author_id_to_action_items.rb
+++ b/db/migrate/20201225131656_populate_author_id_to_action_items.rb
@@ -2,6 +2,8 @@
 
 class PopulateAuthorIdToActionItems < ActiveRecord::Migration[6.0]
   def change
+    return true unless column_exists?(:memberships, :role)
+
     Board.find_each do |board|
       creator = board.memberships.where(role: 'creator').first
       if creator

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,16 +64,16 @@ board3 = Board.find_or_create_by(title: 'TestUser3_RetroBoard')
 board4 = Board.find_or_create_by(title: 'TestUser4_RetroBoard')
 board5 = Board.find_or_create_by(title: 'TestUser5_RetroBoard')
 
-Membership.create([
-                    { user_id: user1.id, board_id: board1.id, role: 'creator', ready: false },
-                    { user_id: user2.id, board_id: board2.id, role: 'creator', ready: false },
-                    { user_id: user2.id, board_id: board3.id, role: 'creator', ready: false },
-                    { user_id: user2.id, board_id: board4.id, role: 'creator', ready: false },
-                    { user_id: user2.id, board_id: board5.id, role: 'creator', ready: false }
-                  ])
-
 # Create creator's board permissions
 # TODO Move creating memeberships and permissions to the operation Boards::Create
+Membership.create([
+                    { user_id: user1.id, board_id: board1.id, ready: false },
+                    { user_id: user2.id, board_id: board2.id, ready: false },
+                    { user_id: user2.id, board_id: board3.id, ready: false },
+                    { user_id: user2.id, board_id: board4.id, ready: false },
+                    { user_id: user2.id, board_id: board5.id, ready: false }
+                  ])
+
 creator_params = [{ board: board1, creator: user1 }, { board: board2, creator: user2 },
                   { board: board3, creator: user2 }, { board: board4, creator: user2 }]
 creator_params.each do |params|
@@ -119,7 +119,6 @@ ActionItem.create(body: 'issue should be fixed', board_id: board1.id, author_id:
 ActionItem.create(body: 'meetings should be held', board_id: board1.id, author_id: user1.id) unless ActionItem.where(body: 'meetings should be held', board_id: board1.id, author_id: user1.id).exists?
 ActionItem.create(body: 'actions should be taken', board_id: board1.id, author_id: user1.id) unless ActionItem.where(body: 'actions should be taken', board_id: board1.id, author_id: user1.id).exists?
 
-Rake::Task['permissions:create_missing_for_boards'].invoke
 Rake::Task['permissions:create_missing_for_cards'].invoke
 Rake::Task['permissions:create_missing_for_comments'].invoke
 Rake::Task['permissions:create_missing_for_like_cards'].invoke

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -1,27 +1,6 @@
 # frozen_string_literal: true
 
 namespace :permissions do
-  desc 'update creators and members with missing permissions for boards'
-  task create_missing_for_boards: :environment do
-    Membership.creator.find_each do |membership|
-      # rubocop:disable Layout/LineLength
-      permission_ids = Permission.creator_permissions.where.not(id: BoardPermissionsUser.select(:permission_id)
-        .where(user: membership.user, board: membership.board)).ids
-      # rubocop:enable Layout/LineLength
-
-      create_board_permissions_users(permission_ids, membership) unless permission_ids.empty?
-    end
-
-    Membership.member.find_each do |membership|
-      # rubocop:disable Layout/LineLength
-      permission_ids = Permission.member_permissions.where.not(id: BoardPermissionsUser.select(:permission_id)
-        .where(user: membership.user, board: membership.board)).ids
-      # rubocop:enable Layout/LineLength
-
-      create_board_permissions_users(permission_ids, membership) unless permission_ids.empty?
-    end
-  end
-
   # rubocop:disable Metrics/MethodLength
   def create_board_permissions_users(permission_ids, membership)
     unless Rails.env.test?

--- a/spec/api/v1/action_items_spec.rb
+++ b/spec/api/v1/action_items_spec.rb
@@ -5,9 +5,6 @@ require 'rails_helper'
 describe 'Action Item API', type: :request do
   let_it_be(:author) { create(:user) }
   let_it_be(:board) { create(:board) }
-  let_it_be(:creatorship) do
-    create(:membership, board: board, user: author, role: 'creator')
-  end
 
   before do
     login_as author
@@ -34,7 +31,7 @@ describe 'Action Item API', type: :request do
     it 'return created action item' do
       request
 
-      expect(json_body['data']['actionItem']).to include('body' => 'test item')
+      expect(json_body.dig('data', 'actionItem')).to include('body' => 'test item')
     end
 
     it 'create action item in db' do
@@ -217,9 +214,6 @@ describe 'Action Item API', type: :request do
 
   describe 'PUT /api/v1/action_items/:id/move' do
     let_it_be(:new_board) { create(:board) }
-    let_it_be(:creatorship2) do
-      create(:membership, board: new_board, user: author, role: 'creator')
-    end
     let_it_be(:action_item) { create(:action_item, board: board) }
 
     let(:request) do

--- a/spec/api/v1/cards_spec.rb
+++ b/spec/api/v1/cards_spec.rb
@@ -6,9 +6,6 @@ describe 'Cards API', type: :request do
   let_it_be(:author) { create(:user) }
   let_it_be(:board) { create(:board) }
   let_it_be(:card) { create(:card) }
-  let_it_be(:creatorship) do
-    create(:membership, board: board, user: author, role: 'creator')
-  end
 
   before do
     login_as author

--- a/spec/api/v1/comments_spec.rb
+++ b/spec/api/v1/comments_spec.rb
@@ -5,9 +5,6 @@ require 'rails_helper'
 describe 'Comments API', type: :request do
   let_it_be(:author) { create(:user) }
   let_it_be(:board) { create(:board) }
-  let_it_be(:creatorship) do
-    create(:membership, board: board, user: author, role: 'creator')
-  end
   let_it_be(:card) { create(:card, board: board, author: author) }
 
   describe 'POST /api/v1/comments' do

--- a/spec/api/v1/membership_spec.rb
+++ b/spec/api/v1/membership_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'Membership API', type: :request do
   let_it_be(:author) { create(:user) }
   let_it_be(:board) { create(:board) }
-  let_it_be(:creatorship) { create(:membership, user: author, board: board, role: 'creator') }
+  let_it_be(:creatorship) { create(:membership, user: author, board: board) }
 
   before { login_as author }
 

--- a/spec/factories/membership_factory.rb
+++ b/spec/factories/membership_factory.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     sequence(:id) { |number| number }
     user
     board
-    role { 'member' }
   end
 end

--- a/spec/graphql/mutations/membersips/destroy_membership_spec.rb
+++ b/spec/graphql/mutations/membersips/destroy_membership_spec.rb
@@ -4,17 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Mutations::DestroyMembershipMutation, type: :request do
   describe '#resolve' do
-    let!(:board) { create(:board) }
+    let(:board) { create(:board) }
     let(:author) { create(:user) }
     let(:non_author) { create(:user) }
-    let!(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
-    end
-    let!(:non_creatorship) do
-      create(:membership, board: board, user: non_author, role: 'member')
-    end
+    let!(:creatorship) { create(:membership, board: board, user: author) }
+    let!(:non_creatorship) { create(:membership, board: board, user: non_author) }
     let_it_be(:member_permission) { create(:permission, identifier: 'some_identifier') }
     let_it_be(:destroy_permission) { create(:permission, identifier: 'destroy_membership') }
+
     let(:request) { post '/graphql', params: { query: query(id: non_creatorship.id) } }
 
     before do
@@ -40,10 +37,7 @@ RSpec.describe Mutations::DestroyMembershipMutation, type: :request do
       it 'returns a membership' do
         request
 
-        json = JSON.parse(response.body)
-        data = json.dig('data', 'destroyMembership')
-
-        expect(data).to include(
+        expect(json_body.dig('data', 'destroyMembership')).to include(
           'id' => non_creatorship.id
         )
       end
@@ -56,8 +50,7 @@ RSpec.describe Mutations::DestroyMembershipMutation, type: :request do
 
       it 'returns unauthorized error' do
         request
-        json = JSON.parse(response.body)
-        message = json['errors'].first['message']
+        message = json_body['errors'].first['message']
 
         expect(message).to eq('You are not authorized to perform this action')
       end

--- a/spec/graphql/mutations/membersips/invite_members_spec.rb
+++ b/spec/graphql/mutations/membersips/invite_members_spec.rb
@@ -4,18 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Mutations::InviteMembersMutation, type: :request do
   describe '.resolve' do
-    let!(:author) { create(:user) }
-    let!(:board) { create(:board) }
-    let!(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
-    end
-    let(:invite_permission) { create(:permission, identifier: 'invite_members') }
-
-    let(:invitee1) { build_stubbed(:user) }
-    let(:invitee2) { build_stubbed(:user) }
-
-    let(:membership1) { build_stubbed(:membership, board: board, user: invitee1) }
-    let(:membership2) { build_stubbed(:membership, board: board, user: invitee2) }
+    let_it_be(:author) { create(:user) }
+    let_it_be(:board) { create(:board) }
+    let_it_be(:invite_permission) { create(:permission, identifier: 'invite_members') }
+    let_it_be(:invitee1) { build_stubbed(:user) }
+    let_it_be(:invitee2) { build_stubbed(:user) }
+    let_it_be(:membership1) { build_stubbed(:membership, board: board, user: invitee1) }
+    let_it_be(:membership2) { build_stubbed(:membership, board: board, user: invitee2) }
 
     let(:request) do
       post '/graphql', params: { query: query(board_slug: board.slug,
@@ -23,6 +18,7 @@ RSpec.describe Mutations::InviteMembersMutation, type: :request do
     end
 
     before do
+      create(:membership, board: board, user: author)
       create(:board_permissions_user, permission: invite_permission, user: author, board: board)
     end
 
@@ -38,10 +34,8 @@ RSpec.describe Mutations::InviteMembersMutation, type: :request do
 
     it 'returns a list of memberships' do
       request
-      json = JSON.parse(response.body)
-      data = json.dig('data', 'inviteMembers', 'memberships')
 
-      expect(data).to match_array(
+      expect(json_body.dig('data', 'inviteMembers', 'memberships')).to match_array(
         [
           {
             'id' => membership1.id,

--- a/spec/graphql/queries/membership_spec.rb
+++ b/spec/graphql/queries/membership_spec.rb
@@ -6,23 +6,18 @@ RSpec.describe Queries::Membership, type: :request do
   describe '.resolve' do
     let!(:author) { create(:user) }
     let!(:board) { create(:board) }
-    let!(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
-    end
+    let!(:membership) { create(:membership, board: board, user: author) }
 
     before { sign_in author }
 
     it 'returns membership for provided id' do
       post '/graphql', params: { query: query(board_slug: board.slug) }
 
-      json = JSON.parse(response.body)
-      data = json['data']['membership']
-
-      expect(data).to include(
+      expect(json_body.dig('data', 'membership')).to include(
         'id' => be_present,
         'board' => { 'id' => board.id.to_s },
         'user' => { 'id' => author.id.to_s },
-        'ready' => creatorship.ready
+        'ready' => membership.ready
       )
     end
   end

--- a/spec/graphql/queries/memberships_spec.rb
+++ b/spec/graphql/queries/memberships_spec.rb
@@ -6,35 +6,28 @@ RSpec.describe Queries::Memberships, type: :request do
   describe '.resolve' do
     let!(:author) { create(:user) }
     let!(:board) { create(:board) }
-    let!(:creatorship) do
-      create(:membership, board: board, user: author, role: 'creator')
-    end
-    let!(:non_author) { create(:user) }
-    let!(:non_creatorship) do
-      create(:membership, board: board, user: non_author, role: 'member')
-    end
+    let!(:membership1) { create(:membership, board: board, user: author) }
+    let!(:member) { create(:user) }
+    let!(:membership2) { create(:membership, board: board, user: member, ready: true) }
 
     before { sign_in author }
 
     it 'returns membership for provided board slug' do
       post '/graphql', params: { query: query(board_slug: board.slug) }
 
-      json = JSON.parse(response.body)
-      data = json['data']['memberships']
-
-      expect(data).to match_array(
+      expect(json_body['data']['memberships']).to match_array(
         [
           {
-            'id' => creatorship.id,
+            'id' => membership1.id,
             'board' => { 'id' => board.id.to_s },
             'user' => { 'id' => author.id.to_s },
-            'ready' => creatorship.ready
+            'ready' => membership1.ready
           },
           {
-            'id' => non_creatorship.id,
+            'id' => membership2.id,
             'board' => { 'id' => board.id.to_s },
-            'user' => { 'id' => non_author.id.to_s },
-            'ready' => creatorship.ready
+            'user' => { 'id' => member.id.to_s },
+            'ready' => membership2.ready
           }
         ]
       )

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Board, type: :model do
   let_it_be(:member) { create(:user) }
   let_it_be(:creator) { create(:user) }
   let_it_be(:membership) { create(:membership, user_id: member.id, board_id: board.id) }
-  let_it_be(:creatorship) do
-    create(:membership, user_id: creator.id, board_id: board.id, role: 'creator')
-  end
+  let_it_be(:creatorship) { create(:membership, user_id: creator.id, board_id: board.id) }
 
   context 'validations' do
     it 'is valid with valid attributes' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -190,4 +190,21 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#creator?' do
+    subject { user.creator?(board) }
+
+    context 'when user is a creator of the board' do
+      let_it_be(:permission) { create(:permission, identifier: Permission::MASTER_CREATOR_ID) }
+      before do
+        create(:board_permissions_user, user: user, board: board, permission: permission)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when user is not a creator of the board' do
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/operations/boards/continue_spec.rb
+++ b/spec/operations/boards/continue_spec.rb
@@ -6,22 +6,10 @@ RSpec.describe Boards::Continue do
   include Dry::Monads[:result]
 
   let!(:prev_creator) { create(:user) }
-  let!(:prev_admin) { create(:user) }
-  let!(:prev_host) { create(:user) }
   let!(:current_user) { create(:user) }
   let!(:prev_board) { create(:board) }
-  let!(:creatorship) do
-    create(:membership, board: prev_board, user: prev_creator, role: 'creator', ready: true)
-  end
-  let!(:adminship) do
-    create(:membership, board: prev_board, user: prev_admin, role: 'admin', ready: true)
-  end
-  let!(:hostship) do
-    create(:membership, board: prev_board, user: prev_host, role: 'host', ready: true)
-  end
-  let!(:membership) do
-    create(:membership, board: prev_board, user: current_user, role: 'member')
-  end
+  let!(:creatorship) { create(:membership, board: prev_board, user: prev_creator, ready: true) }
+  let!(:membership) { create(:membership, board: prev_board, user: current_user) }
 
   subject { described_class.new(prev_board, current_user).call }
 
@@ -64,15 +52,6 @@ RSpec.describe Boards::Continue do
     end
     it 'sets dupicated memberships ready statuses to false' do
       expect(subject.value!.memberships).not_to include(be_ready)
-    end
-    it 'sets prev_creator as the creator of the new board' do
-      expect(subject.value!.memberships.find_by(role: 'creator').user_id).to eq prev_creator.id
-    end
-    it 'sets prev_admin as the admin of the new board' do
-      expect(subject.value!.memberships.find_by(role: 'admin').user_id).to eq prev_admin.id
-    end
-    it 'sets prev_host as the host of the new board' do
-      expect(subject.value!.memberships.find_by(role: 'host').user_id).to eq prev_host.id
     end
     it 'sets previous privacy settings to new board' do
       expect(subject.value!.private).to eq prev_board.private

--- a/spec/serializers/membership_serializer_spec.rb
+++ b/spec/serializers/membership_serializer_spec.rb
@@ -3,16 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe MembershipSerializer do
-  let_it_be(:membership) { create(:membership, role: 'creator') }
+  let_it_be(:membership) { create(:membership) }
 
   subject { described_class.new(membership).to_json }
 
   it 'makes json with id' do
     expect(subject['id']).to be_present
-  end
-
-  it 'makes json with role' do
-    expect(subject).to include '"role":"creator"'
   end
 
   it 'makes json with ready' do

--- a/spec/serializers/users_serializer_spec.rb
+++ b/spec/serializers/users_serializer_spec.rb
@@ -3,16 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe MembershipSerializer do
-  let_it_be(:membership) { create(:membership, role: 'creator') }
+  let_it_be(:membership) { create(:membership) }
 
   subject { described_class.new(membership).to_json }
 
   it 'makes json with id' do
     expect(subject['id']).to be_present
-  end
-
-  it 'makes json with role' do
-    expect(subject).to include '"role":"creator"'
   end
 
   it 'makes json with ready' do

--- a/spec/tasks/permissions_spec.rb
+++ b/spec/tasks/permissions_spec.rb
@@ -21,41 +21,6 @@ RSpec.describe 'permissions.rake' do
     let_it_be(:board) { create(:board) }
     let_it_be(:other_permission) { create(:permission) }
 
-    context 'for boards' do
-      let_it_be(:task_name) { 'permissions:create_missing_for_boards' }
-
-      context 'with creator membership' do
-        let_it_be(:creator_permission) { create(:permission, identifier: 'destroy_board') }
-        before { create(:membership, user: user, board: board, role: 'creator') }
-
-        it 'connects to missing creator permissions' do
-          run_task
-          expect(user.board_permissions).to include(creator_permission)
-        end
-
-        it 'does not connect to non creator_permissions' do
-          run_task
-          expect(user.board_permissions).not_to include(other_permission)
-        end
-      end
-
-      context 'with members' do
-        let_it_be(:member_permission) { create(:permission, identifier: 'toggle_ready_status') }
-
-        before { create(:membership, user: user, board: board, role: 'member') }
-
-        it 'connects to missing member permissions' do
-          run_task
-          expect(user.board_permissions).to include(member_permission)
-        end
-
-        it 'does not connect to non member_permissions' do
-          run_task
-          expect(user.board_permissions).not_to include(other_permission)
-        end
-      end
-    end
-
     context 'for cards' do
       let_it_be(:card_permission) { create(:permission, identifier: 'update_card') }
       let!(:card) { create(:card, author: user) }


### PR DESCRIPTION
We are moving away from using membership in favour of permissions: #225
That's why the membership should contain only `toggle_ready_status`

1. deploy this PR
2. remove the column from membership #462 