### PR TITLE
Fix card create

### DIFF
--- a/app/channels/comments_channel.rb
+++ b/app/channels/comments_channel.rb
@@ -2,12 +2,7 @@
 
 class CommentsChannel < ApplicationCable::Channel
   def subscribed
-    params.deep_transform_keys!(&:underscore)
-    board = Board.find_by(slug: params[:board_slug])
-
-    return reject unless board
-
-    stream_for board
+    stream_from 'comment'
   end
 
   def unsubscribed

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -16,9 +16,9 @@ module API
       def create
         board = Board.find_by!(slug: params[:board_slug])
         authorize! board, to: :create_cards?
-        card = Card.new(card_params.merge!(board: board, author: current_user))
+        card = Boards::Cards::Create.new(current_user, board).call(card_params)
 
-        if card.save
+        if card.success?
           prepare_and_make_response(card)
         else
           render_json_error(card.errors.full_messages)

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -15,6 +15,7 @@ module API
       # app/graphql/mutations/add_comment_mutation.rb
       def create
         board = Board.joins(:cards).find_by(cards: { id: params[:card_id] })
+
         authorize! board, to: :create_comments?
         comment = Comment.new(comment_params.merge!(author: current_user))
 
@@ -61,7 +62,7 @@ module API
       def prepare_and_make_response(comment)
         payload = serialize_resource(comment)
 
-        CommentsChannel.broadcast_to(comment.card.board, payload)
+        ActionCable.server.broadcast('comment', payload)
         render json: payload
       end
     end

--- a/app/operations/boards/cards/create.rb
+++ b/app/operations/boards/cards/create.rb
@@ -4,15 +4,15 @@ module Boards
   module Cards
     class Create
       include Dry::Monads[:result]
-      attr_reader :user
+      attr_reader :user, :board
 
-      def initialize(user)
+      def initialize(user, board)
+        @board = board
         @user = user
       end
 
       def call(card_params)
-        card = Card.new(card_params)
-
+        card = Card.new(card_params.merge(author: user, board: board))
         card.transaction do
           Boards::Cards::BuildPermissions.new(card, user).call(identifiers_scope: 'card')
           card.save!

--- a/spec/api/v1/cards_spec.rb
+++ b/spec/api/v1/cards_spec.rb
@@ -30,7 +30,7 @@ describe 'Cards API', type: :request do
     it 'return created card' do
       request
 
-      expect(json_body['body']).to eq('my test card')
+      expect(json_body['value']['body']).to eq('my test card')
     end
 
     it 'create card in db' do
@@ -38,7 +38,7 @@ describe 'Cards API', type: :request do
     end
 
     it 'broadcast created card' do
-      expect { request }.to have_broadcasted_to('card').with(start_with('{"data":{"card":'))
+      expect { request }.to have_broadcasted_to('card').with(start_with('{"data":{"value":'))
     end
   end
 

--- a/spec/api/v1/comments_spec.rb
+++ b/spec/api/v1/comments_spec.rb
@@ -33,8 +33,8 @@ describe 'Comments API', type: :request do
     end
 
     it 'broadcast created comment' do
-      expect { request }.to have_broadcasted_to(board).from_channel(CommentsChannel)
-                                                      .with(start_with('{"data":{"comment":'))
+      expect { request }.to have_broadcasted_to('comment').from_channel(ActionItemsChannel)
+                                                          .with(start_with('{"data":{"comment":'))
     end
   end
 
@@ -63,8 +63,8 @@ describe 'Comments API', type: :request do
     it 'broadcast updated comment' do
       handler = serialize_resource(comment)
 
-      expect { request }.to have_broadcasted_to(board).from_channel(CommentsChannel)
-                                                      .with(handler)
+      expect { request }.to have_broadcasted_to('comment').from_channel(ActionItemsChannel)
+                                                          .with(handler)
     end
   end
 
@@ -97,8 +97,8 @@ describe 'Comments API', type: :request do
     it 'broadcast deleted comment' do
       handler = serialize_resource(comment)
 
-      expect { request }.to have_broadcasted_to(board).from_channel(CommentsChannel)
-                                                      .with(handler)
+      expect { request }.to have_broadcasted_to('comment').from_channel(ActionItemsChannel)
+                                                          .with(handler)
     end
   end
 
@@ -138,8 +138,8 @@ describe 'Comments API', type: :request do
       it 'broadcast liked comment' do
         handler = serialize_resource(comment)
 
-        expect { request }.to have_broadcasted_to(board).from_channel(CommentsChannel)
-                                                        .with(handler)
+        expect { request }.to have_broadcasted_to('comment').from_channel(ActionItemsChannel)
+                                                            .with(handler)
       end
     end
   end

--- a/spec/operations/boards/cards/create_card_spec.rb
+++ b/spec/operations/boards/cards/create_card_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Boards::Cards::Create do
-  subject { described_class.new(user).call(card_params) }
+  subject { described_class.new(user, board).call(card_params) }
   let_it_be(:user) { create(:user) }
   let_it_be(:board) { create(:board) }
   let_it_be(:permission) { create(:permission, identifier: 'update_card') }


### PR DESCRIPTION
Previously, when cards were created, permissions to update and delete were not built for them.
Fix this [issue](https://www.notion.so/cybergizer/b8b2ac4295b640c89956431a766cab27?v=512e9c0acf7b4cf6836558b26d8bed22&p=614fcbe139144dcc8d5a92625a80f29f)

Also ActionCable wasn't working with comments
Fix this [issue](https://www.notion.so/cybergizer/b8b2ac4295b640c89956431a766cab27?v=512e9c0acf7b4cf6836558b26d8bed22&p=a69959dcaf7645039fe8c8167d089871)